### PR TITLE
fix(ci): replace rustsec/audit-check action with cargo-audit CLI (closes #155)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -32,6 +32,15 @@ jobs:
         run: cargo deny check
 
       - name: Run cargo audit (RustSec advisory database)
-        uses: rustsec/audit-check@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        # Use cargo-audit CLI directly rather than the rustsec/audit-check
+        # wrapper action (#155). The wrapper crashes with "Unexpected end
+        # of JSON input"; the underlying cargo-audit binary is fine. The
+        # CLI route also gives us version control and mirrors the
+        # gitleaks-action → CLI pattern in the global CLAUDE.md.
+        #
+        # cargo-deny step 6 already queries the same RustSec DB; this
+        # step is belt-and-braces defense-in-depth (slightly different
+        # report formats and edge-case behaviour).
+        run: |
+          cargo install cargo-audit --locked
+          cargo audit


### PR DESCRIPTION
## Summary

`audit.yml` step 7 has been failing with `Unexpected end of JSON input` since PR #154 made step 6 (cargo-deny) finally pass — the failure was previously masked by the cargo-deny step aborting first.

The third-party `rustsec/audit-check@v2` wrapper action is broken; the underlying `cargo-audit` binary is fine. Replace the action with a direct CLI invocation.

## Note on the workflow-file-change safety net

This PR touches `.github/workflows/audit.yml`. Per `pr-gate.yml`'s safety net, any workflow change forces a **full platform sweep** (Rust 3-OS matrix + macOS + Linux). Windows is still de-scoped per #148. Total ~10-15 min of CI on this PR.

## Test plan

- [ ] PR Gate passes (full sweep)
- [ ] Merge
- [ ] `audit.yml` runs end-to-end green on the merge to main (step 6 cargo-deny ✓ + step 7 cargo-audit ✓ for the first time in a week)

Closes #155
Refs #149, #150, #151, #152, #153, #154 (the full cargo-deny saga)

🤖 Generated with [Claude Code](https://claude.com/claude-code)