### PR TITLE
fix(ci): drop redundant cargo-audit step (closes #157)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -29,18 +29,9 @@ jobs:
         run: cargo install cargo-deny --locked
 
       - name: Run cargo-deny checks (licenses, bans, advisories, sources)
+        # cargo-deny is the modern superset of cargo-audit. Its `advisories`
+        # check queries the RustSec database directly; the ignore list in
+        # deny.toml is the canonical place to silence individual advisories.
+        # A separate cargo-audit step was tried (#156) but turned out to be
+        # redundant AND had runner-side DB-fetch issues (#157). Dropped.
         run: cargo deny check
-
-      - name: Run cargo audit (RustSec advisory database)
-        # Use cargo-audit CLI directly rather than the rustsec/audit-check
-        # wrapper action (#155). The wrapper crashes with "Unexpected end
-        # of JSON input"; the underlying cargo-audit binary is fine. The
-        # CLI route also gives us version control and mirrors the
-        # gitleaks-action → CLI pattern in the global CLAUDE.md.
-        #
-        # cargo-deny step 6 already queries the same RustSec DB; this
-        # step is belt-and-braces defense-in-depth (slightly different
-        # report formats and edge-case behaviour).
-        run: |
-          cargo install cargo-audit --locked
-          cargo audit


### PR DESCRIPTION
## Summary

Drop the cargo-audit step from `audit.yml`. cargo-deny step 6 already queries the same RustSec advisory database and passes; cargo-audit (its predecessor) is redundant AND was failing to fetch the DB on the runner.

audit.yml is now just: checkout → toolchain → cache → install cargo-deny → run cargo-deny check.

## Note on workflow change

Touches `.github/workflows/audit.yml` → PR Gate forces a full platform sweep (Rust + macOS + Linux; Windows still de-scoped per #148).

## Test plan

- [ ] PR Gate passes
- [ ] Merge
- [ ] `audit.yml` runs **end-to-end green** on the merge — finally completing the saga (#149 → ... → #157)

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)