### PR TITLE
feat: add meedya-core dep (phase 1 of MeedyaSuite-core integration, refs #135)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,6 +601,19 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
@@ -1096,12 +1109,32 @@ dependencies = [
 
 [[package]]
 name = "governor"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
+dependencies = [
+ "cfg-if",
+ "dashmap 5.5.3",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.8.5",
+ "smallvec",
+ "spinning_top",
+]
+
+[[package]]
+name = "governor"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0746aa765db78b521451ef74221663b57ba595bf83f75d0ce23cc09447c8139f"
 dependencies = [
  "cfg-if",
- "dashmap",
+ "dashmap 6.1.0",
  "futures-sink",
  "futures-timer",
  "futures-util",
@@ -1678,6 +1711,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1712,6 +1751,21 @@ dependencies = [
 
 [[package]]
 name = "lofty"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8bc4717ff10833a623b009e9254ae8667c7a59edc3cfb01c37aeeef4b6d54a7"
+dependencies = [
+ "byteorder",
+ "data-encoding",
+ "flate2",
+ "lofty_attr",
+ "log",
+ "ogg_pager 0.6.1",
+ "paste",
+]
+
+[[package]]
+name = "lofty"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca260c51a9c71f823fbfd2e6fbc8eb2ee09834b98c00763d877ca8bfa85cde3e"
@@ -1721,7 +1775,7 @@ dependencies = [
  "flate2",
  "lofty_attr",
  "log",
- "ogg_pager",
+ "ogg_pager 0.7.1",
  "paste",
 ]
 
@@ -1780,6 +1834,131 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest",
+]
+
+[[package]]
+name = "meedya-codecs"
+version = "0.1.0"
+source = "git+https://github.com/MWBMPartners/MeedyaSuite-core?rev=222ca7590493#222ca7590493525a74bb3b47bc541568b2695214"
+dependencies = [
+ "serde",
+ "serde_json",
+ "strum",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml",
+ "tracing",
+ "which",
+]
+
+[[package]]
+name = "meedya-core"
+version = "0.1.0"
+source = "git+https://github.com/MWBMPartners/MeedyaSuite-core?rev=222ca7590493#222ca7590493525a74bb3b47bc541568b2695214"
+dependencies = [
+ "meedya-codecs",
+ "meedya-db",
+ "meedya-fingerprint",
+ "meedya-library-import",
+ "meedya-lyrics",
+ "meedya-metadata",
+ "meedya-providers",
+ "meedya-tags-extended",
+]
+
+[[package]]
+name = "meedya-db"
+version = "0.1.0"
+source = "git+https://github.com/MWBMPartners/MeedyaSuite-core?rev=222ca7590493#222ca7590493525a74bb3b47bc541568b2695214"
+dependencies = [
+ "chrono",
+ "meedya-codecs",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "meedya-fingerprint"
+version = "0.1.0"
+source = "git+https://github.com/MWBMPartners/MeedyaSuite-core?rev=222ca7590493#222ca7590493525a74bb3b47bc541568b2695214"
+dependencies = [
+ "log",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "meedya-library-import"
+version = "0.1.0"
+source = "git+https://github.com/MWBMPartners/MeedyaSuite-core?rev=222ca7590493#222ca7590493525a74bb3b47bc541568b2695214"
+dependencies = [
+ "log",
+ "percent-encoding",
+ "plist",
+]
+
+[[package]]
+name = "meedya-lyrics"
+version = "0.1.0"
+source = "git+https://github.com/MWBMPartners/MeedyaSuite-core?rev=222ca7590493#222ca7590493525a74bb3b47bc541568b2695214"
+dependencies = [
+ "async-trait",
+ "lofty 0.22.4",
+ "meedya-metadata",
+ "quick-xml 0.36.2",
+ "reqwest",
+ "serde",
+ "serde_yaml",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "meedya-metadata"
+version = "0.1.0"
+source = "git+https://github.com/MWBMPartners/MeedyaSuite-core?rev=222ca7590493#222ca7590493525a74bb3b47bc541568b2695214"
+dependencies = [
+ "lofty 0.22.4",
+ "log",
+ "meedya-codecs",
+ "meedya-fingerprint",
+ "mp4ameta",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "toml",
+]
+
+[[package]]
+name = "meedya-providers"
+version = "0.1.0"
+source = "git+https://github.com/MWBMPartners/MeedyaSuite-core?rev=222ca7590493#222ca7590493525a74bb3b47bc541568b2695214"
+dependencies = [
+ "async-trait",
+ "fuzzy-matcher",
+ "governor 0.6.3",
+ "keyring",
+ "meedya-codecs",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "meedya-tags-extended"
+version = "0.1.0"
+source = "git+https://github.com/MWBMPartners/MeedyaSuite-core?rev=222ca7590493#222ca7590493525a74bb3b47bc541568b2695214"
+dependencies = [
+ "lofty 0.21.1",
+ "log",
 ]
 
 [[package]]
@@ -1878,7 +2057,8 @@ dependencies = [
  "gettext-rs",
  "json5",
  "libc",
- "lofty",
+ "lofty 0.22.4",
+ "meedya-core",
  "notify",
  "regex",
  "semver",
@@ -1929,9 +2109,10 @@ version = "1.3.0"
 dependencies = [
  "anyhow",
  "fuzzy-matcher",
- "governor",
+ "governor 0.7.0",
  "jsonwebtoken",
  "keyring",
+ "meedya-core",
  "mm-core",
  "oauth2",
  "reqwest",
@@ -1975,6 +2156,12 @@ dependencies = [
  "tracing",
  "wiremock",
 ]
+
+[[package]]
+name = "mp4ameta"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453e991b2efe96c288cbc2d03a19e353504294559ecb6c03067fff5bd824616d"
 
 [[package]]
 name = "native-tls"
@@ -2171,6 +2358,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
 dependencies = [
  "objc",
+]
+
+[[package]]
+name = "ogg_pager"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87b0bef808533c5890ab77279538212efdbbbd9aa4ef1ccdfcfbf77a42f7e6fa"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -2393,6 +2589,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml 0.38.4",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2460,6 +2669,25 @@ dependencies = [
  "wasi",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2674,6 +2902,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -2698,12 +2927,14 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.6",
 ]
@@ -2750,6 +2981,19 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2757,7 +3001,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2961,6 +3205,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -3323,6 +3580,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3395,7 +3674,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3971,6 +4250,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4161,6 +4446,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4217,6 +4515,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
 ]
 
 [[package]]
@@ -4560,6 +4870,12 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wiremock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,13 @@ rust-version = "1.85"
 
 # Shared dependency versions to keep all crates in sync
 [workspace.dependencies]
-# MeedyaSuite-core — shared core library
-meedya-core = { git = "https://github.com/MWBMPartners/MeedyaSuite-core", branch = "claude/interesting-mirzakhani", features = ["full"] }
+# MeedyaSuite-core — shared core library. Pinned to a specific rev on
+# main for reproducible builds (per #135 acceptance criteria). Bump the
+# rev to consume new upstream features; do NOT switch to `branch =
+# "main"` (non-deterministic builds).
+# Current rev = 222ca7590493 (MeedyaSuite-core PR #37 merge: feat/353-
+# 596-meedya-fingerprint-and-lyrics, 2026-05-26).
+meedya-core = { git = "https://github.com/MWBMPartners/MeedyaSuite-core", rev = "222ca7590493", features = ["full"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,9 @@ rust-version = "1.85"
 
 # Shared dependency versions to keep all crates in sync
 [workspace.dependencies]
+# MeedyaSuite-core — shared core library
+meedya-core = { git = "https://github.com/MWBMPartners/MeedyaSuite-core", branch = "claude/interesting-mirzakhani", features = ["full"] }
+
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/mm-core/Cargo.toml
+++ b/crates/mm-core/Cargo.toml
@@ -11,6 +11,9 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+# MeedyaSuite-core — shared metadata and codec infrastructure
+meedya-core = { workspace = true }
+
 serde = { workspace = true }
 serde_json = { workspace = true }
 json5 = { workspace = true }

--- a/crates/mm-providers/Cargo.toml
+++ b/crates/mm-providers/Cargo.toml
@@ -13,6 +13,9 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+# MeedyaSuite-core — shared metadata provider infrastructure
+meedya-core = { workspace = true }
+
 # Internal crate dependency — core types, config, and error handling
 mm-core = { path = "../mm-core" }
 


### PR DESCRIPTION
## Summary

**Phase 1** of the MeedyaSuite-core integration epic (#135 → #132 → #133 → #134 → #136). Adds `meedya-core` as a workspace dependency wired into `mm-core` and `mm-providers`. **No code changes** yet — that's the scope of #132/#133/#134.

## Provenance

Salvaged + cleaned from `feature/MeedyaManager_MeedyaSuite-core_integration`:
- `0c2a366` — original phase-1 commit (rebased from `713a969` onto current main; same content, new SHA)
- `91e4543` — pin fix (original branch pinned to `claude/interesting-mirzakhani` which no longer exists on MeedyaSuite-core; bumped to specific rev `222ca7590493`)

The old `feature/MeedyaManager_MeedyaSuite-core_integration` branch is **preserved on origin** unchanged.

## What this PR does

1. Adds workspace dep:
   ```toml
   meedya-core = { git = "https://github.com/MWBMPartners/MeedyaSuite-core",
                   rev = "222ca7590493",
                   features = ["full"] }
   ```
2. References it from `mm-core` and `mm-providers` via `{ workspace = true }`
3. Locks `Cargo.lock` with 6 meedya-* crates from upstream (`meedya-core`, `-metadata`, `-providers`, `-fingerprint`, `-db`, `-lyrics`)

## What this PR does NOT do

- **Doesn't remove redundant direct deps** (governor, fuzzy-matcher, keyring, lofty, mp4ameta, async-trait, thiserror). These can only be removed once their consumers are migrated — that's the work in #132/#133/#134. Removing them now would break the build.
- **Doesn't migrate any code.** No `use meedya_core::*` anywhere yet. The dep just resolves and compiles.

## Local verification

```
$ cargo check --workspace --exclude mm-gtk
... 
    Finished `dev` profile in 1m 26s   ✓
```

## #135 acceptance criteria status

- [x] `meedya-core` added as a git dependency with `features = ["full"]`
- [x] `cargo check` succeeds
- [ ] Redundant direct dependencies removed — **deferred to #132-#134** (can't be done without code migration)
- [x] No version conflicts (cargo check passed)
- [ ] CI builds pass — verifying in this PR
- [ ] mm-providers crate scope documented — small doc PR later, post-migration

## Test plan

- [ ] PR Gate passes (rust matrix runs; macOS/Windows-skipped/Linux skip — only Cargo.toml + Cargo.lock changed)
- [ ] Merge
- [ ] Continue to #132 (trait system migration) on a new branch off main

Refs #135 (closed when post-migration cleanup completes)
Refs #132, #133, #134, #136 (subsequent phases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)